### PR TITLE
Support other semi-popular architectures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 c.out
 coverage.html
+
+\.idea/

--- a/sys_linux_arm.go
+++ b/sys_linux_arm.go
@@ -1,0 +1,7 @@
+package keyctl
+
+const (
+	syscall_keyctl   uintptr = 9437495
+	syscall_add_key  uintptr = 9437493
+	syscall_setfsgid uintptr = 9437323
+)

--- a/sys_linux_arm64.go
+++ b/sys_linux_arm64.go
@@ -1,0 +1,7 @@
+package keyctl
+
+const (
+	syscall_keyctl   uintptr = 219
+	syscall_add_key  uintptr = 217
+	syscall_setfsgid uintptr = 152
+)

--- a/sys_linux_ppc.go
+++ b/sys_linux_ppc.go
@@ -1,0 +1,7 @@
+package keyctl
+
+const (
+	syscall_keyctl   uintptr = 271
+	syscall_add_key  uintptr = 269
+	syscall_setfsgid uintptr = 139
+)

--- a/sys_linux_ppc64.go
+++ b/sys_linux_ppc64.go
@@ -1,0 +1,7 @@
+package keyctl
+
+const (
+	syscall_keyctl   uintptr = 271
+	syscall_add_key  uintptr = 269
+	syscall_setfsgid uintptr = 139
+)

--- a/sys_linux_ppc64le.go
+++ b/sys_linux_ppc64le.go
@@ -1,0 +1,7 @@
+package keyctl
+
+const (
+	syscall_keyctl   uintptr = 219
+	syscall_add_key  uintptr = 217
+	syscall_setfsgid uintptr = 152
+)


### PR DESCRIPTION
We've had some users ask to run azcopy on `ppc64le` and `arm64`, so I went ahead and added in a bundle of architectures as well as relatives.

This shouldn't comprise of any real functionality changes, merely just supplies the syscall pointers for other architectures on Linux.