### PR TITLE
fix syscall numbers for arm

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/jiacfan/keyctl
+
+go 1.16

--- a/sys_linux_arm.go
+++ b/sys_linux_arm.go
@@ -1,7 +1,7 @@
 package keyctl
 
 const (
-	syscall_keyctl   uintptr = 9437495
-	syscall_add_key  uintptr = 9437493
-	syscall_setfsgid uintptr = 9437323
+	syscall_keyctl   uintptr = 311
+	syscall_add_key  uintptr = 309
+	syscall_setfsgid uintptr = 139
 )


### PR DESCRIPTION
The previous numbers were not correct at all, and resulted in SIGILL being
raised when called on ARM. I took the updated values from:
https://chromium.googlesource.com/chromiumos/docs/+/master/constants/syscalls.md